### PR TITLE
Changed subscriber to pcl::pointcloud

### DIFF
--- a/include/ar_kinect/ar_kinect.h
+++ b/include/ar_kinect/ar_kinect.h
@@ -48,6 +48,8 @@
 #include <pcl/registration/icp.h>
 #include <pcl/registration/registration.h>
 #include <pcl/registration/transformation_estimation_svd.h>
+#include <pcl_ros/point_cloud.h>
+
 
 #include <opencv/cv.h>
 #include <cv_bridge/cv_bridge.h>
@@ -73,7 +75,7 @@ namespace ar_pose
 
   private:
     void arInit ();
-    void getTransformationCallback (const sensor_msgs::PointCloud2ConstPtr &);
+    void getTransformationCallback (const PointCloud::ConstPtr& msg);
 
     ros::NodeHandle n_;
     tf::TransformBroadcaster broadcaster_;


### PR DESCRIPTION
The way the subscriber is initiated is changed according to pcl_ros library. This saves two casts from pointcloud msg to pcl. (And appears to reduce the execution time inside the callback)

My only concern is: I don't understand how the subscriber obtains the pcl cloud from the ROS messaging system. Subscribing to a pcl pointcloud might therefore have induced delay outside the callback, but I was unable to test this.

(Offtopic: I have also tried out chilimarkers in stead of artoolkit, this seems to further decrease delay and appears slightly more robust, fork is on github)
